### PR TITLE
Added option to keep images in their original size

### DIFF
--- a/fastclass/fc_download.py
+++ b/fastclass/fc_download.py
@@ -115,6 +115,7 @@ def main(infile: str, size: int, crawler: List[str], keep: bool, maxnum:int, out
             os.makedirs(out_resized, exist_ok=True)
 
             files = sorted(glob.glob(raw_folder+'/*'))
+
             source_urls = resize(files, outpath=out_resized, size=SIZE, urls=source_urls)
 
             # write report file

--- a/fastclass/fc_download.py
+++ b/fastclass/fc_download.py
@@ -145,7 +145,7 @@ click.Context.get_usage = click.Context.get_help
                     help='maximum number of images per crawler (lower is faster, 1000 is max)')
 
 @click.option('-s', '--size',  default=299, show_default=True, type=int,
-                    help='image size for rescaling')
+                    help='image size for rescaling. Set to 0 to keep original size.')
 
 @click.option('-o', '--outpath',  default='dataset', show_default=True,
                     help='name of output directory')

--- a/fastclass/imageprocessing.py
+++ b/fastclass/imageprocessing.py
@@ -36,13 +36,13 @@ def resize(files: List[str], \
                 except OSError:
                     # skip truncated files
                     continue
-            
+
                 bg = Image.new('RGBA', size, (255, 255, 255, 0))
                 bg.paste(im, (int((size[0] - im.size[0]) / 2), int((size[1] - im.size[1]) / 2)))
-                bg = bg.convert('RGB')
+
             else:
                 bg = im
-
+            bg = bg.convert('RGB')
             fname, _ = os.path.splitext(os.path.basename(f))
             out = os.path.join(outpath, fname + '.jpg')
             bg.save(out)

--- a/fastclass/imageprocessing.py
+++ b/fastclass/imageprocessing.py
@@ -17,7 +17,11 @@ def resize(files: List[str], \
            size: Tuple[int, int] = (299, 299), \
            urls: Optional[Dict[str, str]] = None) -> Optional[Dict[str, str]]:
     """Resize image to specified size"""
-    print(f'(2) Resizing images to {size}')
+    should_resize = (size[0] > 0 and size[1] > 0)
+    if (should_resize):
+        print(f'(2) Resizing images to {size}')
+    else:
+        print("Not resizing images")
 
     sources = None
     if urls:
@@ -31,9 +35,12 @@ def resize(files: List[str], \
             except OSError:
                 # skip truncated files
                 continue
-            bg = Image.new('RGBA', size, (255, 255, 255, 0))
-            bg.paste(im, (int((size[0] - im.size[0]) / 2), int((size[1] - im.size[1]) / 2)))
-            bg = bg.convert('RGB')
+            if (should_resize):
+                bg = Image.new('RGBA', size, (255, 255, 255, 0))
+                bg.paste(im, (int((size[0] - im.size[0]) / 2), int((size[1] - im.size[1]) / 2)))
+                bg = bg.convert('RGB')
+            else:
+                bg = im
 
             fname, _ = os.path.splitext(os.path.basename(f))
             out = os.path.join(outpath, fname + '.jpg') 

--- a/fastclass/imageprocessing.py
+++ b/fastclass/imageprocessing.py
@@ -30,12 +30,13 @@ def resize(files: List[str], \
     with tqdm(total=len(files)) as t:
         for fcnt, f in enumerate(files):
             im = Image.open(f)
-            try:
-                im.thumbnail(size, Image.ANTIALIAS)
-            except OSError:
-                # skip truncated files
-                continue
             if (should_resize):
+                try:
+                    im.thumbnail(size, Image.ANTIALIAS)
+                except OSError:
+                    # skip truncated files
+                    continue
+            
                 bg = Image.new('RGBA', size, (255, 255, 255, 0))
                 bg.paste(im, (int((size[0] - im.size[0]) / 2), int((size[1] - im.size[1]) / 2)))
                 bg = bg.convert('RGB')
@@ -43,7 +44,7 @@ def resize(files: List[str], \
                 bg = im
 
             fname, _ = os.path.splitext(os.path.basename(f))
-            out = os.path.join(outpath, fname + '.jpg') 
+            out = os.path.join(outpath, fname + '.jpg')
             bg.save(out)
 
             if urls:


### PR DESCRIPTION
Sometimes we wish to keep images in their original size instead of resizing (e.g. for data augmentation purposes)