### PR TITLE
Improve fastclass fcc

### DIFF
--- a/fastclass/fc_clean.py
+++ b/fastclass/fc_clean.py
@@ -31,7 +31,7 @@ is given in the title bar (X indicated a mark for deletion).\r
 The counter in the titlebar gives number of classified images\r
 vs the total number in the input folder.\r
 
-In the output csv file 1,2 depcit class assignments/ ratings, 
+In the output csv file 1,2 indicate class assignments/ ratings, 
 -1 indicates files marked for deletion (if not excluded with -d)."""
 
 
@@ -41,16 +41,12 @@ class AppTk(tk.Frame):
         INFOLDER = kwargs['infolder']
         OUTFOLDER = kwargs['outfolder']
 
-        if OUTFOLDER:
-            pass
-        else:
+        if not OUTFOLDER:
             OUTFOLDER = INFOLDER + '.clean'
             os.makedirs(OUTFOLDER, exist_ok=True)
 
         NOCOPY = kwargs['nocopy']
- 
-        for e in ['infolder', 'outfolder', 'nocopy']:
-            kwargs.pop(e)
+        [kwargs.pop(e) for e in ['infolder', 'outfolder', 'nocopy']
 
         tk.Frame.__init__(self,*args,**kwargs)
 

--- a/fastclass/fc_clean.py
+++ b/fastclass/fc_clean.py
@@ -164,12 +164,8 @@ class AppTk(tk.Frame):
                 rows_all.append(row)
 
             for ftype, rows in zip(["all", "clean"], [rows_all, rows_clean]):
-                with open(
-                    os.path.join(
-                        self.infolder.replace(" ", "_") + "_report_%s.csv" % ftype
-                    ),
-                    "w",
-                ) as f:
+                foutname = self.infolder.replace(" ", "_") + f"_report_{ftype}.csv"
+                with open(foutname, "w") as f:
                     f.write("file;rank\n")
                     for row in rows:
                         f.write(";".join(row) + "\n")

--- a/fastclass/fc_clean.py
+++ b/fastclass/fc_clean.py
@@ -92,41 +92,45 @@ class AppTk(tk.Frame):
         self.display_next()
     
     @property
-    def total(self):
-        return len(self.filelist)
-        
+    def cur_file(self):
+        return self.filelist[self._index]
+
     @property
-    def classified(self):
+    def no_classified(self):
         cnt = 0
         for d in digits:
-            if self.filelist[self._index] in self._class[f'c{d}']:
+            if self.cur_file in self._class[f'c{d}']:
                 cnt += len(self._class[f'c{d}'])            
-        if self.filelist[self._index] in self._delete: 
+        if self.cur_file in self._delete: 
             cnt += len(self._delete)
         return cnt 
+
+    @property
+    def no_total(self):
+        return len(self.filelist)
 
     @property
     def title(self):
 
         def get_class():
             for d in digits:
-                if self.filelist[self._index] in self._class[f'c{d}']:
+                if self.cur_file in self._class[f'c{d}']:
                     return f'[ {d} ] '
-            if self.filelist[self._index] in self._delete: 
+            if self.cur_file in self._delete: 
                 return '[ X ] '
             return '[   ] '
 
-        return (os.path.basename( self.filelist[self._index]) + 
+        return (os.path.basename( self.cur_file ) + 
                 " - " +
                 get_class() + 
-                f" ({self.classified}/{self.total})")
+                f" ({self.no_classified}/{self.no_total})")
 
     def print_titlebar(self):
         self.parent.title(self.title)
 
     def callback(self, event=None):
         def button_action(char):
-            self._class[f'c{char}'].add(self.filelist[self._index]) 
+            self._class[f'c{char}'].add(self.cur_file) 
             self.display_next()
 
         if event.keysym in digits:
@@ -134,7 +138,7 @@ class AppTk(tk.Frame):
         elif event.keysym == 'space': #'<space>':
             button_action('1')
         elif event.keysym == 'd':
-            self._delete.add(self.filelist[self._index])
+            self._delete.add(self.cur_file)
             self.display_next()
         elif event.keysym == 'Left': #'<Left>':
             self.display_prev()
@@ -150,7 +154,10 @@ class AppTk(tk.Frame):
                     if f in self._class[f'c{d}']:
                         row = (f, d)
                 
-                row = (f, 'D') if f in self._delete else rows_clean.append(row)
+                if f in self._delete:
+                    row = (f, 'D')
+                else:
+                    rows_clean.append(row)
                 rows_all.append(row)
 
             for ftype, rows in zip(['all', 'clean'], [rows_all, rows_clean]):
@@ -179,7 +186,7 @@ class AppTk(tk.Frame):
         self.print_titlebar()
         self._index+=1
         try:
-            f=self.filelist[self._index]
+            f=self.cur_file
         except IndexError:
             self._index=-1  #go back to the beginning of the list.
             self.display_next()
@@ -196,7 +203,7 @@ class AppTk(tk.Frame):
 
         self._index-=1
         try:
-            f=self.filelist[self._index]
+            f = self.cur_file
         except IndexError:
             self._index=-1  #go back to the beginning of the list.
             self.display_next()

--- a/fastclass/fc_clean.py
+++ b/fastclass/fc_clean.py
@@ -6,10 +6,11 @@
 
 import click
 import glob
-import itertools
+import itertools as it
 import os
 from PIL import ImageTk, Image
 import tkinter as tk
+from tkinter import ttk
 import shutil
 
 from .imageprocessing import image_pad
@@ -53,7 +54,7 @@ class AppTk(tk.Frame):
 
         NOCOPY = kwargs["nocopy"]
 
-        # remove this kwargs before passing them into tk frame
+        # remove these kwargs before passing them into tk frame
         [kwargs.pop(e) for e in ["infolder", "outfolder", "nocopy"]]
 
         tk.Frame.__init__(self, parent, **kwargs)
@@ -66,9 +67,7 @@ class AppTk(tk.Frame):
         self._class = {f"c{d}": set() for d in digits}
         self._delete = set()
 
-        files = list(
-            itertools.chain(*[glob.glob(f"{INFOLDER}/*.{x}") for x in suffixes])
-        )
+        files = list(it.chain(*[glob.glob(f"{INFOLDER}/*.{x}") for x in suffixes]))
 
         self.filelist = sorted(set(files))
         if len(self.filelist) == 0:
@@ -186,9 +185,9 @@ class AppTk(tk.Frame):
     def setup(self):
         self.Label = tk.Label(self)
         self.Label.grid(row=0, column=0, columnspan=6, rowspan=6)  # , sticky=tk.N+tk.S)
-        self.Button1 = tk.Button(self, text="Prev", command=self.display_prev)
+        self.Button1 = ttk.Button(self, text="Prev", command=self.display_prev)
         self.Button1.grid(row=5, column=7, sticky=tk.S)
-        self.Button2 = tk.Button(self, text="Next", command=self.display_next)
+        self.Button2 = ttk.Button(self, text="Next", command=self.display_next)
         self.Button2.grid(row=5, column=8, sticky=tk.S)
 
     def display_next(self):

--- a/fastclass/fc_clean.py
+++ b/fastclass/fc_clean.py
@@ -36,7 +36,7 @@ In the output csv file 1,2 indicate class assignments/ ratings,
 
 
 class AppTk(tk.Frame):
-    def __init__(self, *args, **kwargs):
+    def __init__(self, parent, **kwargs):
 
         INFOLDER = kwargs['infolder']
         OUTFOLDER = kwargs['outfolder']
@@ -48,11 +48,11 @@ class AppTk(tk.Frame):
         NOCOPY = kwargs['nocopy']
         [kwargs.pop(e) for e in ['infolder', 'outfolder', 'nocopy']]
 
-        tk.Frame.__init__(self,*args,**kwargs)
+        tk.Frame.__init__(self, parent, **kwargs)
+        self.parent = parent
 
         # bind keys
-        args[0].bind('<Key>', self.callback)
-        self.root = args[0]
+        self.parent.bind('<Key>', self.callback)
 
         # store classification
         self._class = {f'c{c}': set() for c in range(1,10)}
@@ -81,8 +81,8 @@ class AppTk(tk.Frame):
         self.setup()
 
         # raise window to top
-        self.root.lift()
-        self.root.attributes("-topmost", True)
+        self.parent.lift()
+        self.parent.attributes("-topmost", True)
         
         # show first image
         self.display_next()
@@ -118,7 +118,7 @@ class AppTk(tk.Frame):
                 f" ({self.classified}/{self.total})")
 
     def print_titlebar(self):
-        self.root.title(self.title)
+        self.parent.title(self.title)
 
     def callback(self, event=None):
         def button_action(char):
@@ -164,7 +164,7 @@ class AppTk(tk.Frame):
                 for r in rows_clean:
                     shutil.copy(r[0], self.outfolder)    
 
-            self.root.destroy()
+            self.parent.destroy()
         else:
             pass
 

--- a/fastclass/fc_clean.py
+++ b/fastclass/fc_clean.py
@@ -8,6 +8,7 @@ import click
 import glob
 import itertools as it
 import os
+from pathlib import Path
 from PIL import ImageTk, Image
 import tkinter as tk
 from tkinter import ttk
@@ -45,12 +46,14 @@ digits = "123456789"
 class AppTk(tk.Frame):
     def __init__(self, parent, **kwargs):
 
-        INFOLDER = kwargs["infolder"]
+        INFOLDER = Path(kwargs["infolder"])
         OUTFOLDER = kwargs["outfolder"]
 
         if OUTFOLDER is None:
-            OUTFOLDER = INFOLDER + ".clean"
-            os.makedirs(OUTFOLDER, exist_ok=True)
+            OUTFOLDER = INFOLDER.parent / (INFOLDER.name + ".clean")
+            OUTFOLDER.mkdir(exist_ok=True)
+        else:
+            OUTFOLDER = Path(OUTFOLDER)
 
         NOCOPY = kwargs["nocopy"]
 
@@ -67,7 +70,7 @@ class AppTk(tk.Frame):
         self._class = {f"c{d}": set() for d in digits}
         self._delete = set()
 
-        files = list(it.chain(*[glob.glob(f"{INFOLDER}/*.{x}") for x in suffixes]))
+        files = list(it.chain(*[INFOLDER.glob(f"*.{x}") for x in suffixes]))
 
         self.filelist = sorted(set(files))
         if len(self.filelist) == 0:
@@ -121,12 +124,9 @@ class AppTk(tk.Frame):
                 return "[ X ] "
             return "[   ] "
 
-        return (
-            os.path.basename(self.cur_file)
-            + " - "
-            + get_class()
-            + f" ({self.no_classified}/{self.no_total})"
-        )
+        stats = f"{self.no_classified}/{self.no_total}"
+        label = f"{self.cur_file.name} - {get_class()} ({stats})"
+        return label
 
     def print_titlebar(self):
         self.parent.title(self.title)

--- a/fastclass/fc_clean.py
+++ b/fastclass/fc_clean.py
@@ -46,7 +46,7 @@ class AppTk(tk.Frame):
             os.makedirs(OUTFOLDER, exist_ok=True)
 
         NOCOPY = kwargs['nocopy']
-        [kwargs.pop(e) for e in ['infolder', 'outfolder', 'nocopy']
+        [kwargs.pop(e) for e in ['infolder', 'outfolder', 'nocopy']]
 
         tk.Frame.__init__(self,*args,**kwargs)
 
@@ -73,7 +73,7 @@ class AppTk(tk.Frame):
         self.nocopy = NOCOPY
 
         self._classified = 0
-        self._index=-1
+        self._index = -1
         
         self.size = (299, 299)
 

--- a/fastclass/fc_clean.py
+++ b/fastclass/fc_clean.py
@@ -34,6 +34,9 @@ vs the total number in the input folder.\r
 In the output csv file 1,2 indicate class assignments/ ratings, 
 -1 indicates files marked for deletion (if not excluded with -d)."""
 
+# supported suffixes
+suffixes = ['jpg', 'jpeg', 'png', 'tif', 'tiff']
+suffixes += [x.upper() for x in suffixes]
 
 class AppTk(tk.Frame):
     def __init__(self, parent, **kwargs):
@@ -58,9 +61,6 @@ class AppTk(tk.Frame):
         self._class = {f'c{c}': set() for c in range(1,10)}
         self._delete = set()
 
-        # config settings
-        suffixes = ['jpg', 'jpeg', 'png', 'tif', 'tiff']
-        suffixes += [x.upper() for x in suffixes]
         files = list(itertools.chain(*[glob.glob(f'{INFOLDER}/*.{x}') for x in suffixes]))
 
         self.filelist = sorted(set(files))

--- a/fastclass/fc_clean.py
+++ b/fastclass/fc_clean.py
@@ -38,6 +38,8 @@ In the output csv file 1,2 indicate class assignments/ ratings,
 suffixes = ['jpg', 'jpeg', 'png', 'tif', 'tiff']
 suffixes += [x.upper() for x in suffixes]
 
+digits = '123456789'
+
 class AppTk(tk.Frame):
     def __init__(self, parent, **kwargs):
 
@@ -60,7 +62,7 @@ class AppTk(tk.Frame):
         self.parent.bind('<Key>', self.callback)
 
         # store classification
-        self._class = {f'c{c}': set() for c in range(1,10)}
+        self._class = {f'c{d}': set() for d in digits}
         self._delete = set()
 
         files = list(itertools.chain(*[glob.glob(f'{INFOLDER}/*.{x}') for x in suffixes]))
@@ -96,9 +98,9 @@ class AppTk(tk.Frame):
     @property
     def classified(self):
         cnt = 0
-        for c in '123456789':
-            if self.filelist[self._index] in self._class[f'c{c}']:
-                cnt += len(self._class[f'c{c}'])            
+        for d in digits:
+            if self.filelist[self._index] in self._class[f'c{d}']:
+                cnt += len(self._class[f'c{d}'])            
         if self.filelist[self._index] in self._delete: 
             cnt += len(self._delete)
         return cnt 
@@ -107,9 +109,9 @@ class AppTk(tk.Frame):
     def title(self):
 
         def get_class():
-            for c in '123456789':
-                if self.filelist[self._index] in self._class[f'c{c}']:
-                    return f'[ {c} ] '
+            for d in digits:
+                if self.filelist[self._index] in self._class[f'c{d}']:
+                    return f'[ {d} ] '
             if self.filelist[self._index] in self._delete: 
                 return '[ X ] '
             return '[   ] '
@@ -127,7 +129,7 @@ class AppTk(tk.Frame):
             self._class[f'c{char}'].add(self.filelist[self._index]) 
             self.display_next()
 
-        if event.keysym in '123456789':
+        if event.keysym in digits:
             button_action(event.keysym)
         elif event.keysym == 'space': #'<space>':
             button_action('1')
@@ -144,9 +146,9 @@ class AppTk(tk.Frame):
             rows_all, rows_clean = [], []
             for f in self.filelist:
                 row = (f, '?')
-                for c in '123456789':
-                    if f in self._class[f'c{c}']:
-                        row = (f, c)
+                for d in digits:
+                    if f in self._class[f'c{d}']:
+                        row = (f, d)
                 
                 row = (f, 'D') if f in self._delete else rows_clean.append(row)
                 rows_all.append(row)
@@ -168,10 +170,10 @@ class AppTk(tk.Frame):
     def setup(self):
         self.Label=tk.Label(self)
         self.Label.grid(row=0, column=0, columnspan=6, rowspan=6) #, sticky=tk.N+tk.S)
-        self.Button=tk.Button(self, text="Prev", command=self.display_prev)
-        self.Button.grid(row=5, column=7, sticky=tk.S)
-        self.Button=tk.Button(self, text="Next", command=self.display_next)
-        self.Button.grid(row=5, column=8, sticky=tk.S)
+        self.Button1=tk.Button(self, text="Prev", command=self.display_prev)
+        self.Button1.grid(row=5, column=7, sticky=tk.S)
+        self.Button2=tk.Button(self, text="Next", command=self.display_next)
+        self.Button2.grid(row=5, column=8, sticky=tk.S)
 
     def display_next(self):
         self.print_titlebar()

--- a/fastclass/fc_clean.py
+++ b/fastclass/fc_clean.py
@@ -49,6 +49,8 @@ class AppTk(tk.Frame):
             os.makedirs(OUTFOLDER, exist_ok=True)
 
         NOCOPY = kwargs['nocopy']
+
+        # remove this kwargs before passing them into tk frame
         [kwargs.pop(e) for e in ['infolder', 'outfolder', 'nocopy']]
 
         tk.Frame.__init__(self, parent, **kwargs)
@@ -139,26 +141,21 @@ class AppTk(tk.Frame):
         elif event.keysym == "x":
 
             # write report file
-            rows_all = []
-            rows_clean = []
+            rows_all, rows_clean = [], []
             for f in self.filelist:
                 row = (f, '?')
                 for c in '123456789':
                     if f in self._class[f'c{c}']:
                         row = (f, c)
-                if f in self._delete: 
-                    row = (f, 'D')
-                else:
-                    rows_clean.append(row) 
+                
+                row = (f, 'D') if f in self._delete else rows_clean.append(row)
                 rows_all.append(row)
 
-            with open(os.path.join(self.infolder.replace(' ','_') + '_report_all.csv'), 'w') as f:
-                f.write('file;rank\n')
-                for row in rows_all: f.write(';'.join(row) + '\n')
-
-            with open(os.path.join(self.infolder.replace(' ','_') + '_report_clean.csv'), 'w') as f:
-                f.write('file;rank\n')
-                for row in rows_clean: f.write(';'.join(row) + '\n')                
+            for ftype, rows in zip(['all', 'clean'], [rows_all, rows_clean]):
+                with open(os.path.join(self.infolder.replace(' ','_') + '_report_%s.csv' % ftype), 'w') as f:
+                    f.write('file;rank\n')
+                    for row in rows:
+                        f.write(';'.join(row) + '\n')
 
             if not self.nocopy:
                 for r in rows_clean:


### PR DESCRIPTION
Ok, **fcc** was always a kinda sad excuse for a GUI and especially the internal design pretty poor. So I finally took the time to break it up and redesign the internal logic.

In addition, I finally added buttons for the key bindings so one can also classify and delete using button clicks. However, using keystrokes is still *much* faster and more convenient to me.

Also, visual bugs occurring on MacOS Mojave should now be fixed.

All around a major revamp. Let me know if you encounter issues on your platforms. 